### PR TITLE
ER-757: Fixed retailer id

### DIFF
--- a/ding_unilogin/ding_unilogin.module
+++ b/ding_unilogin/ding_unilogin.module
@@ -423,12 +423,14 @@ function _ding_unilogin_login($username) {
     }
 
     if ($access) {
-      $institutions = $user->getInstitutionsIds();
-      $municipalities = $user->getInstitutionMunicipalities($institutions);
+      $institutionIds = $user->getInstitutionsIds();
+      $municipalities = $user->getInstitutionMunicipalities($institutionIds);
+      $institutions = $user->getInstitutions() ?: [];
+      $unilogin_data['institutions'] = $institutions;
 
-      $unilogin_data['institutions'] = $user->getInstitutions();
-
-      $libraries = publizon_filter_libraries_list($municipalities);
+      // Get retailer id from first institution.
+      $municipalityIds = !empty($institutions) ? [reset($institutions)->kommunenr] : [];
+      $libraries = publizon_filter_libraries_list($municipalityIds);
       if (!empty($libraries)) {
         // Take the first one.
         $library = reset($libraries);


### PR DESCRIPTION
https://jira.itkdev.dk/browse/ER-757

When a user belongs to multiple institutions, the retailer id stored on the user may not match the institution id used when creating a loan. We fix this by getting the retailer id from the institution used when creating a loan (i.e. the first institution on the user).

All this institution/retailer stuff could really benefit from a thorough refactoring, but that's a task for a later time.