### PR TITLE
DEVSUPP-301: Added cors http headers

### DIFF
--- a/ding_unilogin/ding_unilogin.install
+++ b/ding_unilogin/ding_unilogin.install
@@ -21,6 +21,7 @@ function ding_unilogin_uninstall() {
   variable_del('ding_unilogin_municipalities');
   variable_del('ding_unilogin_api_token_read');
   variable_del('ding_unilogin_api_token_write');
+  variable_del('ding_unilogin_api_allowed_http_origins');
 }
 
 /**
@@ -74,4 +75,3 @@ function ding_unilogin_update_7102() {
 function ding_unilogin_update_7103() {
   _ding_unilogin_update_municipalities();
 }
-

--- a/ding_unilogin/ding_unilogin.module
+++ b/ding_unilogin/ding_unilogin.module
@@ -778,6 +778,18 @@ function ding_unilogin_api_router() {
  */
 function ding_unilogin_jsonapi_deliver($result = NULL) {
   drupal_add_http_header('content-type', 'application/vnd.api+json');
+
+  $http_origin = $_SERVER['HTTP_ORIGIN'] ?? NULL;
+  if (_ding_unilogin_is_allowed_http_origin($http_origin)) {
+    // Set Cross-Origin Resource Sharing headers
+    // (cf. https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+    // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+    drupal_add_http_header('access-control-allow-origin', $http_origin);
+    // Allow our custom authorization header.
+    // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+    drupal_add_http_header('access-control-allow-headers', implode(',', ['x-authorization', 'content-type']));
+  }
+
   drupal_page_is_cacheable(FALSE);
 
   if ($result instanceof \Exception) {
@@ -801,6 +813,26 @@ function ding_unilogin_jsonapi_deliver($result = NULL) {
   }
 
   echo drupal_json_encode($result);
+}
+
+/**
+ * Check if http origin is allowed.
+ *
+ * @param string|null $http_origin
+ *   The http origin.
+ *
+ * @return bool
+ *   True if and only if http origin is set and allowed.
+ */
+function _ding_unilogin_is_allowed_http_origin($http_origin) {
+  if (empty($http_origin)) {
+    return FALSE;
+  }
+
+  $spec = variable_get('ding_unilogin_api_allowed_http_origins');
+  $allowed_http_origins = array_map('trim', explode(PHP_EOL, $spec));
+
+  return in_array($http_origin, $allowed_http_origins, TRUE);
 }
 
 /**

--- a/ding_unilogin/includes/ding_unilogin.admin.inc
+++ b/ding_unilogin/includes/ding_unilogin.admin.inc
@@ -111,6 +111,13 @@ function ding_unilogin_admin_api_form($form, &$form_state) {
     '#description' => t('Token needed to access the api. Leave empty to generate a random token.'),
   );
 
+  $form['api']['ding_unilogin_api_allowed_http_origins'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Allowed http origins (one per line)'),
+    '#default_value' => variable_get('ding_unilogin_api_allowed_http_origins', 'https://givadgang.uni-login.dk'),
+    '#description' => t('Allowed http origins, e.g. <pre>https://givadgang.uni-login.dk</pre>'),
+  );
+
   $form['ding_unilogin_api_endpoints'] = array(
     '#type' => 'fieldset',
     '#title' => t('Api endpoints'),

--- a/ding_unilogin/src/Controller/InstitutionController.php
+++ b/ding_unilogin/src/Controller/InstitutionController.php
@@ -23,11 +23,15 @@ class InstitutionController  extends  ApiController {
    * @throws \Drupal\ding_unilogin\Exception\HttpException
    */
   public function handle(array $path) {
+    // Always allow 'OPTIONS' requests.
+    $method = $_SERVER['REQUEST_METHOD'];
+    if ('OPTIONS' === $method) {
+      return 'OK';
+    }
+
     $this->checkAuthorization($path);
 
     if (empty($path)) {
-      $method = $_SERVER['REQUEST_METHOD'];
-
       switch ($method) {
         case 'POST':
           return $this->update();


### PR DESCRIPTION
https://jira.itkdev.dk/browse/DEVSUPP-301

It seems that JavaScript running in plugins in Google Chrome now require CORS headers to work when performing HTTP request to foreign domains. This code sets the required CORS headers.