### PR TITLE
SUPPDEV-33: Fix paragraphs item field settings

### DIFF
--- a/breol_inspiration/breol_inspiration.module
+++ b/breol_inspiration/breol_inspiration.module
@@ -20,3 +20,14 @@ function breol_inspiration_node_validate($node, $form, &$form_state) {
     }
   }
 }
+
+/**
+ * Implements hook_field_default_field_bases_alter().
+ *
+ * Make sure that we can pick news in news carousels.
+ */
+function breol_inspiration_field_default_field_bases_alter(&$fields) {
+  if (isset($fields['field_picked_articles'])) {
+    $fields['field_picked_articles']['settings']['handler_settings']['target_bundles'] = ['breol_news' => 'breol_news'];
+  }
+}


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPPDEV-33

The features `reol_news_paragraph` and `breol_inspiration` clash on the settings of the `field_picked_articles` field. This adds a hook to fix this clash and make 'breol_inspiration' win.
