### PR TITLE
ER-1092: UNI•Login special paths

### DIFF
--- a/ding_unilogin/ding_unilogin.install
+++ b/ding_unilogin/ding_unilogin.install
@@ -22,8 +22,8 @@ function ding_unilogin_uninstall() {
   variable_del('ding_unilogin_api_token_read');
   variable_del('ding_unilogin_api_token_write');
   variable_del('ding_unilogin_api_allowed_http_origins');
-  variable_del('ding_unilogin_special_paths');
-  variable_del('ding_unilogin_special_paths_redirect_path');
+  variable_del('ding_unilogin_error_paths');
+  variable_del('ding_unilogin_error_paths_redirect_path');
 }
 
 /**

--- a/ding_unilogin/ding_unilogin.install
+++ b/ding_unilogin/ding_unilogin.install
@@ -22,6 +22,8 @@ function ding_unilogin_uninstall() {
   variable_del('ding_unilogin_api_token_read');
   variable_del('ding_unilogin_api_token_write');
   variable_del('ding_unilogin_api_allowed_http_origins');
+  variable_del('ding_unilogin_special_paths');
+  variable_del('ding_unilogin_special_paths_redirect_path');
 }
 
 /**

--- a/ding_unilogin/ding_unilogin.module
+++ b/ding_unilogin/ding_unilogin.module
@@ -18,6 +18,21 @@ use Drupal\ding_unilogin\Exception\HttpException;
  * re-trigger it later (after logging in via UNI•Login).
  */
 function ding_unilogin_init() {
+  // Authenticated users with no "update" access to specials paths should be
+  // redirected to the special redirect path.
+  if (user_is_logged_in()) {
+    global $user;
+    $node = menu_get_object();
+    if (!$node || !node_access('update', $node, $user)) {
+      $path = current_path();
+      $patterns = variable_get('ding_unilogin_special_paths', '');
+      $redirect_path = variable_get('ding_unilogin_special_paths_redirect_path', 'user');
+      if ($redirect_path !== $path && drupal_match_path($path, $patterns)) {
+        drupal_goto($redirect_path);
+      }
+    }
+  }
+
   drupal_add_js(drupal_get_path('module', 'ding_unilogin') . '/js/ding_unilogin_monkeypatch.js', 'file');
   _ding_unilogin_handle_login();
 }

--- a/ding_unilogin/ding_unilogin.module
+++ b/ding_unilogin/ding_unilogin.module
@@ -18,15 +18,15 @@ use Drupal\ding_unilogin\Exception\HttpException;
  * re-trigger it later (after logging in via UNI•Login).
  */
 function ding_unilogin_init() {
-  // Authenticated users with no "update" access to specials paths should be
-  // redirected to the special redirect path.
+  // Authenticated users with no "update" access to errors paths should be
+  // redirected to the error redirect path.
   if (user_is_logged_in()) {
     global $user;
     $node = menu_get_object();
     if (!$node || !node_access('update', $node, $user)) {
       $path = current_path();
-      $patterns = variable_get('ding_unilogin_special_paths', '');
-      $redirect_path = variable_get('ding_unilogin_special_paths_redirect_path', 'user');
+      $patterns = variable_get('ding_unilogin_error_paths', '');
+      $redirect_path = variable_get('ding_unilogin_error_paths_redirect_path', 'user');
       if ($redirect_path !== $path && drupal_match_path($path, $patterns)) {
         drupal_goto($redirect_path);
       }

--- a/ding_unilogin/includes/ding_unilogin.admin.inc
+++ b/ding_unilogin/includes/ding_unilogin.admin.inc
@@ -85,6 +85,27 @@ function ding_unilogin_admin_settings_form($form, &$form_state) {
     '#description' => t('The WS05 project to check for access to.'),
   );
 
+  // Miscellaneus settings.
+  $form['misc'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Miscellaneus'),
+    '#description' => t('Miscellaneus settings.'),
+  );
+
+  $form['misc']['ding_unilogin_special_paths'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Special paths'),
+    '#default_value' => variable_get('ding_unilogin_special_paths', ''),
+    '#description' => t('Special paths. One per line.'),
+  );
+
+  $form['misc']['ding_unilogin_special_paths_redirect_path'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Special paths redirect path'),
+    '#default_value' => variable_get('ding_unilogin_special_paths_redirect_path', 'user'),
+    '#description' => t('Special paths redirect path.'),
+  );
+
   // Make the form look like at system form.
   $form = system_settings_form($form);
 

--- a/ding_unilogin/includes/ding_unilogin.admin.inc
+++ b/ding_unilogin/includes/ding_unilogin.admin.inc
@@ -92,18 +92,18 @@ function ding_unilogin_admin_settings_form($form, &$form_state) {
     '#description' => t('Miscellaneus settings.'),
   );
 
-  $form['misc']['ding_unilogin_special_paths'] = array(
+  $form['misc']['ding_unilogin_error_paths'] = array(
     '#type' => 'textarea',
-    '#title' => t('Special paths'),
-    '#default_value' => variable_get('ding_unilogin_special_paths', ''),
-    '#description' => t('Special paths. One per line.'),
+    '#title' => t('Error paths'),
+    '#default_value' => variable_get('ding_unilogin_error_paths', ''),
+    '#description' => t('Error paths (e.g. node/65) that should not be accessible by authenticated users unless they have edit access. One path per line.'),
   );
 
-  $form['misc']['ding_unilogin_special_paths_redirect_path'] = array(
+  $form['misc']['ding_unilogin_error_paths_redirect_path'] = array(
     '#type' => 'textfield',
-    '#title' => t('Special paths redirect path'),
-    '#default_value' => variable_get('ding_unilogin_special_paths_redirect_path', 'user'),
-    '#description' => t('Special paths redirect path.'),
+    '#title' => t('Error paths redirect path'),
+    '#default_value' => variable_get('ding_unilogin_error_paths_redirect_path', 'user'),
+    '#description' => t('The path to redirect authenticated users to when they access an error path.'),
   );
 
   // Make the form look like at system form.


### PR DESCRIPTION
https://jira.itkdev.dk/browse/ER-1092

If UNI•Login for some reason fails at STIL (e.g. due to performance issues), the users is redirected to an error page (currently `/content/unilogin`) telling that the user cannot log in. If the user clicks “Log in” from this page and manages to log in, he will be returned to the error page and may not notice that he actually is logged in.

This PR fixes this UI issue by denying authorized† user access to a configurable list of pages and redirecting them to a configurable path. 

† Authorized users with `update` access to a page (i.e. a node) can still view it.