### PR TITLE
SUPP0RT-735: Allowed zero members of institution

### DIFF
--- a/ding_unilogin/src/Controller/Api/InstitutionController.php
+++ b/ding_unilogin/src/Controller/Api/InstitutionController.php
@@ -108,7 +108,7 @@ class InstitutionController extends ApiController {
       if (!preg_match('/^[a-z0-9]{6}$/i', (string) $id)) {
         throw new HttpBadRequestException(sprintf('Invalid id: %s', $id));
       }
-      if (!is_int($item['number_of_members']) || $item['number_of_members'] <= 0) {
+      if (!is_int($item['number_of_members']) || $item['number_of_members'] < 0) {
         throw new HttpBadRequestException(sprintf('Invalid number_of_members: %d', $item['number_of_members']));
       }
 


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-735

GivAdgang doesn't report the number of members anymore. We allow zero members, but don't yet remove the `number_of_members` field as it may be used somewhere by someone (being an api provider comes with great powers and responsibility) …
