### PR TITLE
Hotfix/1430 frontend weight

### DIFF
--- a/features/breol_frontend/breol_frontend.install
+++ b/features/breol_frontend/breol_frontend.install
@@ -61,3 +61,15 @@ function breol_frontend_update_7104() {
 function breol_frontend_update_7105() {
   image_style_flush(image_style_load('ding_list_medium'));
 }
+
+/**
+ * Update module weight to ensure alter hooks run after reol_base.
+ */
+function breol_frontend_update_7106() {
+  // This will ensure that "emne ord" is not displayed on the search result
+  // page.
+  db_update('system')
+    ->fields(array('weight' => 10100))
+    ->condition('name', 'breol_frontend', '=')
+    ->execute();
+}


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/ER-1430

#### Description

Do to changes in module weight (to ensure adgangsplatformen works correctly) the breol_frontend module hooks where now overriden by reol_base.

This results in "Emne ord" was shown in the search result.

#### Screenshot of the result

![Screenshot 2022-12-06 at 21 55 42](https://user-images.githubusercontent.com/111397/206021145-5b3ba25b-5152-46bf-bdd7-6e5dc5170673.png)

#### Additional comments or questions

N/A
