### PR TITLE
Revert "Revert "SUPP0RT-735: Allowed zero members of institution""

### DIFF
--- a/ding_unilogin/src/Controller/Api/InstitutionController.php
+++ b/ding_unilogin/src/Controller/Api/InstitutionController.php
@@ -108,7 +108,7 @@ class InstitutionController extends ApiController {
       if (!preg_match('/^[a-z0-9]{6}$/i', (string) $id)) {
         throw new HttpBadRequestException(sprintf('Invalid id: %s', $id));
       }
-      if (!is_int($item['number_of_members']) || $item['number_of_members'] <= 0) {
+      if (!is_int($item['number_of_members']) || $item['number_of_members'] < 0) {
         throw new HttpBadRequestException(sprintf('Invalid number_of_members: %d', $item['number_of_members']));
       }
 


### PR DESCRIPTION
Reverts eReolen/ereolengo#82

https://jira.itkdev.dk/browse/ER-1440

eReolen GO want's to – and has to – live with not being able to report the number of members for now.